### PR TITLE
feat: add workflow to update readme

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,19 @@
+name: Update README with scripts
+
+on:
+  push:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update README
+        run: |
+          python update_readme.py
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -am "chore: update README with scripts"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # utils
 Useful scripts collection built along the journey
 
-# TODO
-- Add a new workflow to update the readme with names of scripts and a short description.
+## extract-dashboards.sh
+Fetch all Grafana dashboards via the Grafana Operator API and store each one as a JSON file under the directory defined by FOLDER.
+
+## rename.sh
+Rename every file and directory under ./the-graph to lowercase while preserving the directory structure. Existing lowercase targets are skipped to avoid overwriting.
+
+## status-page-sync.sh
+Download a single Grafana dashboard from the Grafana Operator API and save it to the FOLDER directory as a JSON file. Useful for syncing the status page.
+
+## test-alert.sh
+Send a test alert to a local Alertmanager instance, repeatedly firing until the user resolves it, to verify alert delivery and routing.
+
+## update-sops.sh
+Iterate over all *.enc and *.env files in the tree and refresh their SOPS encryption keys using `sops updatekeys`.
+
+## rework_dashboards.py
+Rework Grafana dashboard JSON files: - If file has {"dashboard": {...}, "meta": {...}}, unwrap to just {...} (the "dashboard" content). - Ensure a templating variable of type "datasource" named DS_PROMETHEUS pointing to VictoriaMetrics-ops. - Replace all "datasource" fields (object or string) across the dashboard with "${DS_PROMETHEUS}", skipping Grafana's internal annotation datasource objects ({"type":"datasource","uid":"grafana"}). By default, only objects are rewritten conservatively when they are Prometheus-like; use --all-sources to rewrite string datasources too.
+
+## update_readme.py
+Generate README listing all scripts with descriptions.
+

--- a/update_readme.py
+++ b/update_readme.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Generate README listing all scripts with descriptions.
+
+Scans the repository for Python and shell scripts in the root directory and
+updates README.md so that each script is listed with a ``##`` header followed by
+its description.
+"""
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+README_PATH = REPO_ROOT / "README.md"
+
+# The static header that will be kept at the top of README.md
+README_HEADER = "# utils\nUseful scripts collection built along the journey\n"
+
+
+def extract_description(path: Path) -> str:
+    """Return the leading comment or docstring describing the script."""
+    if path.suffix == ".py":
+        with path.open("r", encoding="utf-8") as f:
+            try:
+                module = ast.parse(f.read())
+                doc = ast.get_docstring(module)
+                if doc:
+                    first_paragraph = doc.strip().split("\n\n", 1)[0]
+                    return " ".join(line.strip() for line in first_paragraph.splitlines())
+            except SyntaxError:
+                pass
+        # Fallback to comments if no docstring
+    desc_lines = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith("#!"):
+                continue
+            if line.startswith("#"):
+                desc_lines.append(line.lstrip("# "))
+            elif desc_lines and line == "":
+                break
+            elif desc_lines:
+                break
+        if desc_lines:
+            return " ".join(l.strip() for l in desc_lines)
+    return "No description available"
+
+
+def generate_readme_content() -> str:
+    scripts = sorted(Path(REPO_ROOT).glob("*.sh")) + sorted(Path(REPO_ROOT).glob("*.py"))
+    sections = []
+    for script in scripts:
+        desc = extract_description(script)
+        sections.append(f"## {script.name}\n{desc}\n")
+    return README_HEADER + "\n" + "\n".join(sections) + "\n"
+
+
+def main() -> None:
+    content = generate_readme_content()
+    README_PATH.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate README sections for each script via update_readme.py
- add GitHub Actions workflow to regenerate README on each push

## Testing
- `python -m py_compile update_readme.py`
- `python update_readme.py`


------
https://chatgpt.com/codex/tasks/task_b_689f72cf90b4832bacfd81884e7fa8b6