### PR TITLE
Standardize script indentation to two spaces

### DIFF
--- a/clean-ns.sh
+++ b/clean-ns.sh
@@ -17,8 +17,8 @@ for resource in $(kubectl api-resources --verbs=list --namespaced -o name); do
 
     read -p "Do you want to delete? (y/n): " answer
     if [[ "$answer" != "y" && "$answer" != "Y" ]]; then
-        echo "Not deleting"
-        continue
+      echo "Not deleting"
+      continue
     fi
 
     kubectl delete "$resource" --all -n "$NS" --wait=false --ignore-not-found=true

--- a/conf2vmrule.py
+++ b/conf2vmrule.py
@@ -29,263 +29,292 @@ from typing import Optional, Tuple, List
 
 # --- Patterns to extract values (support inner quotes/newlines) ---
 RE_SERVICE_NAME = re.compile(r'apply\s+Service\s+"([^"]+)"')
-RE_METRIC_NAME  = re.compile(r'vars\.check_prometheus_metric_name\s*=\s*(["\'])(.*?)\1', re.DOTALL)
-RE_METRIC_QUERY = re.compile(r'vars\.check_prometheus_metric_query\s*=\s*(["\'])(.*?)\1', re.DOTALL)
-RE_WARN         = re.compile(r'vars\.check_prometheus_metric_warning\s*=\s*(["\'])(.*?)\1', re.DOTALL)
-RE_CRIT         = re.compile(r'vars\.check_prometheus_metric_critical\s*=\s*(["\'])(.*?)\1', re.DOTALL)
+RE_METRIC_NAME = re.compile(
+    r'vars\.check_prometheus_metric_name\s*=\s*(["\'])(.*?)\1', re.DOTALL)
+RE_METRIC_QUERY = re.compile(
+    r'vars\.check_prometheus_metric_query\s*=\s*(["\'])(.*?)\1', re.DOTALL)
+RE_WARN = re.compile(
+    r'vars\.check_prometheus_metric_warning\s*=\s*(["\'])(.*?)\1', re.DOTALL)
+RE_CRIT = re.compile(
+    r'vars\.check_prometheus_metric_critical\s*=\s*(["\'])(.*?)\1', re.DOTALL)
+
 
 def extract(text: str, regex: re.Pattern) -> Optional[str]:
-    m = regex.search(text)
-    if not m:
-        return None
-    try:
-        return m.group(2)  # value inside quotes
-    except IndexError:
-        return m.group(1)
+  m = regex.search(text)
+  if not m:
+    return None
+  try:
+    return m.group(2)  # value inside quotes
+  except IndexError:
+    return m.group(1)
+
 
 def parse_threshold(raw: Optional[str]) -> Optional[str]:
-    if not raw:
-        return None
-    s = raw.strip()
-    if ":" in s:
-        left, right = s.split(":", 1)
-        right = right.strip()
-        return right if right not in ("", "~") else left.strip()
-    return s
+  if not raw:
+    return None
+  s = raw.strip()
+  if ":" in s:
+    left, right = s.split(":", 1)
+    right = right.strip()
+    return right if right not in ("", "~") else left.strip()
+  return s
+
 
 def metric_to_slug(name: str) -> str:
-    return name.strip().lower().replace("_", "-")
+  return name.strip().lower().replace("_", "-")
+
 
 def metric_to_words(name: str) -> str:
-    return name.strip().lower().replace("_", " ")
+  return name.strip().lower().replace("_", " ")
+
 
 # --- Query cleaning utilities ---
 
-def _split_label_matchers(s: str) -> List[str]:
-    """Split label matchers by commas *outside* quotes; return raw matcher strings."""
-    parts = []
-    buf = []
-    in_single = False
-    in_double = False
-    esc = False
-    for ch in s:
-        if esc:
-            buf.append(ch)
-            esc = False
-            continue
-        if ch == "\\":
-            buf.append(ch)
-            esc = True
-            continue
-        if ch == "'" and not in_double:
-            in_single = not in_single
-            buf.append(ch)
-            continue
-        if ch == '"' and not in_single:
-            in_double = not in_double
-            buf.append(ch)
-            continue
-        if ch == "," and not in_single and not in_double:
-            parts.append("".join(buf).strip())
-            buf = []
-            continue
-        buf.append(ch)
-    if buf:
-        parts.append("".join(buf).strip())
-    return [p for p in parts if p]
 
-_PLACEHOLDER_RE = re.compile(r'(%[^%]+%|\{\{[^}]+\}\}|\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*)')
-_LABEL_MATCHER_RE = re.compile(r'^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(=~|!~|=|!=)\s*(.+?)\s*$')
+def _split_label_matchers(s: str) -> List[str]:
+  """Split label matchers by commas *outside* quotes; return raw matcher strings."""
+  parts = []
+  buf = []
+  in_single = False
+  in_double = False
+  esc = False
+  for ch in s:
+    if esc:
+      buf.append(ch)
+      esc = False
+      continue
+    if ch == "\\":
+      buf.append(ch)
+      esc = True
+      continue
+    if ch == "'" and not in_double:
+      in_single = not in_single
+      buf.append(ch)
+      continue
+    if ch == '"' and not in_single:
+      in_double = not in_double
+      buf.append(ch)
+      continue
+    if ch == "," and not in_single and not in_double:
+      parts.append("".join(buf).strip())
+      buf = []
+      continue
+    buf.append(ch)
+  if buf:
+    parts.append("".join(buf).strip())
+  return [p for p in parts if p]
+
+
+_PLACEHOLDER_RE = re.compile(
+    r'(%[^%]+%|\{\{[^}]+\}\}|\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*)')
+_LABEL_MATCHER_RE = re.compile(
+    r'^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(=~|!~|=|!=)\s*(.+?)\s*$')
+
 
 def clean_query(expr: str) -> str:
-    """
+  """
     Remove label matchers whose values contain placeholders (e.g., hostname='%HOSTNAME%').
     If a label set becomes empty, remove the entire `{ ... }`.
     Brace/quote aware.
     """
-    def has_placeholder(s: str) -> bool:
-        return bool(_PLACEHOLDER_RE.search(s))
 
-    def reconstruct_labelset(content: str) -> str:
-        matchers = _split_label_matchers(content)
-        kept = []
-        for m in matchers:
-            mobj = _LABEL_MATCHER_RE.match(m.strip())
-            if not mobj:
-                # Keep unrecognized fragments to be conservative
-                kept.append(m.strip())
-                continue
-            key, op, val = mobj.groups()
-            v = val.strip()
-            inner = v[1:-1] if (len(v) >= 2 and ((v[0] == v[-1] == '"') or (v[0] == v[-1] == "'"))) else v
-            if has_placeholder(inner):
-                continue
-            kept.append(f"{key}{op}{v}" if v == val.strip() else m.strip())
-        if not kept:
-            return ""  # signal to remove entire label set
-        return "{" + ", ".join(kept) + "}"
+  def has_placeholder(s: str) -> bool:
+    return bool(_PLACEHOLDER_RE.search(s))
 
-    out = []
-    i = 0
-    n = len(expr)
-    in_single = in_double = False
-    while i < n:
-        ch = expr[i]
-        if ch == "'" and not in_double:
-            in_single = not in_single
-            out.append(ch)
-            i += 1
-            continue
-        if ch == '"' and not in_single:
-            in_double = not in_double
-            out.append(ch)
-            i += 1
-            continue
-        if ch == "{" and not in_single and not in_double:
-            # capture until matching }
-            depth = 1
-            j = i + 1
-            sub_in_single = sub_in_double = False
-            content = []
-            while j < n and depth > 0:
-                cj = expr[j]
-                if cj == "'" and not sub_in_double:
-                    sub_in_single = not sub_in_single
-                    content.append(cj)
-                    j += 1
-                    continue
-                if cj == '"' and not sub_in_single:
-                    sub_in_double = not sub_in_double
-                    content.append(cj)
-                    j += 1
-                    continue
-                if cj == "{" and not sub_in_single and not sub_in_double:
-                    depth += 1
-                    content.append(cj)
-                    j += 1
-                    continue
-                if cj == "}" and not sub_in_single and not sub_in_double:
-                    depth -= 1
-                    if depth == 0:
-                        j += 1
-                        break
-                    content.append(cj)
-                    j += 1
-                    continue
-                content.append(cj)
-                j += 1
-            inner = "".join(content)
-            rebuilt = reconstruct_labelset(inner) if ("{" not in inner and "}" not in inner) else "{" + inner + "}"
-            if rebuilt == "":
-                # remove entire label set
-                pass
-            else:
-                out.append(rebuilt)
-            i = j
-            continue
-        out.append(ch)
-        i += 1
-    result = "".join(out)
-    result = result.replace("{ ", "{").replace(" }", "}")
-    return result
+  def reconstruct_labelset(content: str) -> str:
+    matchers = _split_label_matchers(content)
+    kept = []
+    for m in matchers:
+      mobj = _LABEL_MATCHER_RE.match(m.strip())
+      if not mobj:
+        # Keep unrecognized fragments to be conservative
+        kept.append(m.strip())
+        continue
+      key, op, val = mobj.groups()
+      v = val.strip()
+      inner = v[1:-1] if (len(v) >= 2 and ((v[0] == v[-1] == '"') or
+                                           (v[0] == v[-1] == "'"))) else v
+      if has_placeholder(inner):
+        continue
+      kept.append(f"{key}{op}{v}" if v == val.strip() else m.strip())
+    if not kept:
+      return ""  # signal to remove entire label set
+    return "{" + ", ".join(kept) + "}"
+
+  out = []
+  i = 0
+  n = len(expr)
+  in_single = in_double = False
+  while i < n:
+    ch = expr[i]
+    if ch == "'" and not in_double:
+      in_single = not in_single
+      out.append(ch)
+      i += 1
+      continue
+    if ch == '"' and not in_single:
+      in_double = not in_double
+      out.append(ch)
+      i += 1
+      continue
+    if ch == "{" and not in_single and not in_double:
+      # capture until matching }
+      depth = 1
+      j = i + 1
+      sub_in_single = sub_in_double = False
+      content = []
+      while j < n and depth > 0:
+        cj = expr[j]
+        if cj == "'" and not sub_in_double:
+          sub_in_single = not sub_in_single
+          content.append(cj)
+          j += 1
+          continue
+        if cj == '"' and not sub_in_single:
+          sub_in_double = not sub_in_double
+          content.append(cj)
+          j += 1
+          continue
+        if cj == "{" and not sub_in_single and not sub_in_double:
+          depth += 1
+          content.append(cj)
+          j += 1
+          continue
+        if cj == "}" and not sub_in_single and not sub_in_double:
+          depth -= 1
+          if depth == 0:
+            j += 1
+            break
+          content.append(cj)
+          j += 1
+          continue
+        content.append(cj)
+        j += 1
+      inner = "".join(content)
+      rebuilt = reconstruct_labelset(inner) if (
+          "{" not in inner and "}" not in inner) else "{" + inner + "}"
+      if rebuilt == "":
+        # remove entire label set
+        pass
+      else:
+        out.append(rebuilt)
+      i = j
+      continue
+    out.append(ch)
+    i += 1
+  result = "".join(out)
+  result = result.replace("{ ", "{").replace(" }", "}")
+  return result
+
 
 # --- YAML building ---
 
-def build_rule_block(metric_for_text: str, expr_left: str, threshold: str, severity: str) -> str:
-    words = metric_to_words(metric_for_text)
-    expr_line = f"{expr_left} > {threshold}"
-    return (
-        f"    - alert: {metric_for_text}\n"
-        f"      annotations:\n"
-        f"        summary: \"{words}\"\n"
-        f"        description: \"{words} at {{ $value }} from {{ $labels.hostname }}\"\n"
-        f"      expr: |\n"
-        f"        {expr_line}\n"
-        f"      labels:\n"
-        f"        severity: {severity}\n"
-    )
+
+def build_rule_block(metric_for_text: str, expr_left: str, threshold: str,
+                     severity: str) -> str:
+  words = metric_to_words(metric_for_text)
+  expr_line = f"{expr_left} > {threshold}"
+  return (
+      f"    - alert: {metric_for_text}\n"
+      f"      annotations:\n"
+      f"        summary: \"{words}\"\n"
+      f"        description: \"{words} at {{ $value }} from {{ $labels.hostname }}\"\n"
+      f"      expr: |\n"
+      f"        {expr_line}\n"
+      f"      labels:\n"
+      f"        severity: {severity}\n")
+
 
 def convert_conf_to_yaml(conf_text: str) -> Tuple[str, str]:
-    # Extract fields
-    service_name = extract(conf_text, RE_SERVICE_NAME) or "unnamed_service"
-    metric_name = extract(conf_text, RE_METRIC_NAME) or service_name
-    metric_query = extract(conf_text, RE_METRIC_QUERY)
-    warn_raw = extract(conf_text, RE_WARN)
-    crit_raw = extract(conf_text, RE_CRIT)
+  # Extract fields
+  service_name = extract(conf_text, RE_SERVICE_NAME) or "unnamed_service"
+  metric_name = extract(conf_text, RE_METRIC_NAME) or service_name
+  metric_query = extract(conf_text, RE_METRIC_QUERY)
+  warn_raw = extract(conf_text, RE_WARN)
+  crit_raw = extract(conf_text, RE_CRIT)
 
-    warn = parse_threshold(warn_raw)
-    crit = parse_threshold(crit_raw)
+  warn = parse_threshold(warn_raw)
+  crit = parse_threshold(crit_raw)
 
-    meta = metric_to_slug(metric_name)
+  meta = metric_to_slug(metric_name)
 
-    # Expr LHS: prefer cleaned query if available; else fall back to metric name
-    expr_left = clean_query(metric_query) if metric_query else metric_name
+  # Expr LHS: prefer cleaned query if available; else fall back to metric name
+  expr_left = clean_query(metric_query) if metric_query else metric_name
 
-    # Header
-    header = (
-        "apiVersion: operator.victoriametrics.com/v1beta1\n"
-        "kind: VMRule\n"
-        "metadata:\n"
-        f"  name: {meta}\n"
-        "spec:\n"
-        "  groups:\n"
-        f"  - name: {meta}\n"
-        "    rules:\n"
-    )
+  # Header
+  header = ("apiVersion: operator.victoriametrics.com/v1beta1\n"
+            "kind: VMRule\n"
+            "metadata:\n"
+            f"  name: {meta}\n"
+            "spec:\n"
+            "  groups:\n"
+            f"  - name: {meta}\n"
+            "    rules:\n")
 
-    rules = ""
-    if warn is not None:
-        rules += build_rule_block(metric_name, expr_left, warn, "warning")
-        if not rules.endswith("\n"):
-            rules += "\n"
-    if crit is not None:
-        if rules and not rules.endswith("\n"):
-            rules += "\n"
-        rules += build_rule_block(metric_name, expr_left, crit, "critical")
+  rules = ""
+  if warn is not None:
+    rules += build_rule_block(metric_name, expr_left, warn, "warning")
+    if not rules.endswith("\n"):
+      rules += "\n"
+  if crit is not None:
+    if rules and not rules.endswith("\n"):
+      rules += "\n"
+    rules += build_rule_block(metric_name, expr_left, crit, "critical")
 
-    if not rules:
-        # If no thresholds, still output a single rule with just the query (no comparator).
-        if metric_query:
-            words = metric_to_words(metric_name)
-            rules += (
-                f"    - alert: {metric_name}\n"
-                f"      annotations:\n"
-                f"        summary: \"{words}\"\n"
-                f"        description: \"{words} at {{ $value }} from {{ $labels.hostname }}\"\n"
-                f"      expr: |\n"
-                f"        {expr_left}\n"
-                f"      labels:\n"
-                f"        severity: info\n"
-            )
-        else:
-            raise ValueError("No thresholds (warning/critical) found and no query available in the .conf file.")
+  if not rules:
+    # If no thresholds, still output a single rule with just the query (no comparator).
+    if metric_query:
+      words = metric_to_words(metric_name)
+      rules += (
+          f"    - alert: {metric_name}\n"
+          f"      annotations:\n"
+          f"        summary: \"{words}\"\n"
+          f"        description: \"{words} at {{ $value }} from {{ $labels.hostname }}\"\n"
+          f"      expr: |\n"
+          f"        {expr_left}\n"
+          f"      labels:\n"
+          f"        severity: info\n")
+    else:
+      raise ValueError(
+          "No thresholds (warning/critical) found and no query available in the .conf file."
+      )
 
-    return metric_name, header + rules
+  return metric_name, header + rules
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Convert myAlert.conf to a VMRule YAML.")
-    parser.add_argument("conf_path", help="Path to the .conf file to convert")
-    parser.add_argument("-o", "--output", help="Write result to this path (overwrites if exists)")
-    parser.add_argument("-w", "--write", action="store_true",
-                        help="Write next to input, using same name with .yaml extension")
-    parser.add_argument("--encoding", default="utf-8", help="File encoding (default: utf-8)")
-    args = parser.parse_args()
+  parser = argparse.ArgumentParser(
+      description="Convert myAlert.conf to a VMRule YAML.")
+  parser.add_argument("conf_path", help="Path to the .conf file to convert")
+  parser.add_argument("-o",
+                      "--output",
+                      help="Write result to this path (overwrites if exists)")
+  parser.add_argument(
+      "-w",
+      "--write",
+      action="store_true",
+      help="Write next to input, using same name with .yaml extension")
+  parser.add_argument("--encoding",
+                      default="utf-8",
+                      help="File encoding (default: utf-8)")
+  args = parser.parse_args()
 
-    conf_p = Path(args.conf_path)
-    text = conf_p.read_text(encoding=args.encoding)
-    metric_name, yaml_text = convert_conf_to_yaml(text)
+  conf_p = Path(args.conf_path)
+  text = conf_p.read_text(encoding=args.encoding)
+  metric_name, yaml_text = convert_conf_to_yaml(text)
 
-    if args.output:
-        out_p = Path(args.output)
-        out_p.write_text(yaml_text, encoding="utf-8")
-        print(f"Wrote {out_p}")
-    elif args.write:
-        out_p = conf_p.with_suffix(".yaml")
-        out_p.write_text(yaml_text, encoding="utf-8")
-        print(f"Wrote {out_p}")
-    else:
-        # Dry-run: print to stdout
-        print(yaml_text)
+  if args.output:
+    out_p = Path(args.output)
+    out_p.write_text(yaml_text, encoding="utf-8")
+    print(f"Wrote {out_p}")
+  elif args.write:
+    out_p = conf_p.with_suffix(".yaml")
+    out_p.write_text(yaml_text, encoding="utf-8")
+    print(f"Wrote {out_p}")
+  else:
+    # Dry-run: print to stdout
+    print(yaml_text)
+
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/extract-dashboards.sh
+++ b/extract-dashboards.sh
@@ -12,8 +12,8 @@ FOLDER=dashboard-result
 mkdir -p "$FOLDER"
 
 curl -s "https://$GRAFANA_AUTH@$GRAFANA_URL/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards" \
-| jq -c '.items[] | {title: .spec.title, spec: .spec}' \
-| while IFS= read -r dash; do
+  | jq -c '.items[] | {title: .spec.title, spec: .spec}' \
+  | while IFS= read -r dash; do
     title=$(echo "$dash" | jq -r '.title' | sed 's|/|>|g' | sed 's/ /-/g')
     echo "$dash" | jq '.spec' > "$FOLDER/$title.json"
   done

--- a/migrate-arch-nix.sh
+++ b/migrate-arch-nix.sh
@@ -11,12 +11,21 @@ CONFIRM=1
 DRYRUN=0
 INCLUDE_YAY=0
 
-while (( "$#" )); do
+while (("$#")); do
   case "$1" in
-    --yes|-y) CONFIRM=0; shift ;;
-    --dry-run) DRYRUN=1; shift ;;
-    --include-yay) INCLUDE_YAY=1; shift ;;
-    -h|--help)
+    --yes | -y)
+      CONFIRM=0
+      shift
+      ;;
+    --dry-run)
+      DRYRUN=1
+      shift
+      ;;
+    --include-yay)
+      INCLUDE_YAY=1
+      shift
+      ;;
+    -h | --help)
       echo "Usage: $0 [--yes|-y] [--dry-run] [--include-yay]"
       exit 0
       ;;
@@ -27,13 +36,13 @@ while (( "$#" )); do
   esac
 done
 
-have_cmd() { command -v "$1" >/dev/null 2>&1; }
+have_cmd() { command -v "$1" > /dev/null 2>&1; }
 
 # 1) Retrieve explicitly installed Arch packages (AUR included)
 if have_cmd yay; then
-  mapfile -t ARCH_PKGS < <(yay -Qqe 2>/dev/null | sort -u)
+  mapfile -t ARCH_PKGS < <(yay -Qqe 2> /dev/null | sort -u)
 elif have_cmd pacman; then
-  mapfile -t ARCH_PKGS < <(pacman -Qqe 2>/dev/null | sort -u)
+  mapfile -t ARCH_PKGS < <(pacman -Qqe 2> /dev/null | sort -u)
 else
   echo "Error: neither 'yay' nor 'pacman' found in PATH." >&2
   exit 1
@@ -49,22 +58,22 @@ fi
 # Keep only the name without version.
 mapfile -t HM_PKGS < <(
   home-manager packages \
-  | sed -E 's#.*/##' \
-  | sed -E 's/\.drv$//' \
-  | sed -E 's/-[0-9][0-9A-Za-z._+~-]*$//' \
-  | sed '/^$/d' \
-  | sort -u
+    | sed -E 's#.*/##' \
+    | sed -E 's/\.drv$//' \
+    | sed -E 's/-[0-9][0-9A-Za-z._+~-]*$//' \
+    | sed '/^$/d' \
+    | sort -u
 )
 
 # 3) Mapping Nix -> Arch for divergent names
 #    Add personal mappings here if needed.
 declare -A MAP_NIX_TO_ARCH=(
   # Nix                  Arch
-  [kubernetes-helm]=helm
-  [yq-go]=go-yq
-  [zoom-us]=zoom
-  [kubelogin-oidc]=kubelogin
-  [qbittorrent-enhanced]=qbittorrent
+  [kubernetes - helm]=helm
+  [yq - go]=go-yq
+  [zoom - us]=zoom
+  [kubelogin - oidc]=kubelogin
+  [qbittorrent - enhanced]=qbittorrent
 )
 
 # Set of Arch packages for O(1) lookup
@@ -163,8 +172,11 @@ fi
 if [[ $CONFIRM -ne 0 ]]; then
   read -r -p "Confirm removal via 'yay -Rns'? [y/N] " ans
   case "$ans" in
-    y|Y|yes|YES) ;;
-    *) echo "Cancelled."; exit 0 ;;
+    y | Y | yes | YES) ;;
+    *)
+      echo "Cancelled."
+      exit 0
+      ;;
   esac
 fi
 

--- a/rename.sh
+++ b/rename.sh
@@ -3,12 +3,9 @@
 # Description: Rename all files and directories under ./the-graph to lowercase without overwriting existing entries.
 # Functioning: Traverses the directory tree and renames each item to its lowercase counterpart if the destination does not exist.
 # How to use: Run without arguments from the repository root; it operates on ./the-graph.
-for SRC in $(find ./the-graph -depth)
-do
-    DST=$(dirname "${SRC}")/$(basename "${SRC}" | tr '[A-Z]' '[a-z]')
-    if [ "${SRC}" != "${DST}" ]
-    then
-        [ ! -e "${DST}" ] && mv -T "${SRC}" "${DST}" || echo "${SRC} was not renamed"
-    fi
+for SRC in $(find ./the-graph -depth); do
+  DST=$(dirname "${SRC}")/$(basename "${SRC}" | tr '[A-Z]' '[a-z]')
+  if [ "${SRC}" != "${DST}" ]; then
+    [ ! -e "${DST}" ] && mv -T "${SRC}" "${DST}" || echo "${SRC} was not renamed"
+  fi
 done
-

--- a/rework_dashboards.py
+++ b/rework_dashboards.py
@@ -11,170 +11,221 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
+
 def parse_args():
-    p = argparse.ArgumentParser(description="Rework Grafana dashboard JSON files.")
-    p.add_argument("inputs", nargs="+", help="Input files and/or directories")
-    p.add_argument("-o", "--output-dir", default=None, help="Write outputs under this directory (mirror structure)")
-    p.add_argument("--glob", default="*.json", help="Glob to match when inputs include directories (default: *.json)")
-    p.add_argument("--in-place", action="store_true", help="Overwrite files in place")
-    p.add_argument("--ds-name", default="VictoriaMetrics-ops", help="Datasource name to set as current (default: VictoriaMetrics-ops)")
-    p.add_argument("--var-name", default="DS_PROMETHEUS", help="Dashboard variable name (default: DS_PROMETHEUS)")
-    mode = p.add_mutually_exclusive_group()
-    mode.add_argument("--prom-only", action="store_true", help='Only rewrite datasource OBJECTS with type=="prometheus"; leave STRING values untouched (conservative)')
-    mode.add_argument("--all-sources", action="store_true", help="Rewrite both OBJECT and STRING datasource fields (except Grafana internal annotations)")
-    p.add_argument("--dry-run", action="store_true", help="Do not write files, just print what would be done")
-    return p.parse_args()
+  p = argparse.ArgumentParser(
+      description="Rework Grafana dashboard JSON files.")
+  p.add_argument("inputs", nargs="+", help="Input files and/or directories")
+  p.add_argument("-o",
+                 "--output-dir",
+                 default=None,
+                 help="Write outputs under this directory (mirror structure)")
+  p.add_argument(
+      "--glob",
+      default="*.json",
+      help="Glob to match when inputs include directories (default: *.json)")
+  p.add_argument("--in-place",
+                 action="store_true",
+                 help="Overwrite files in place")
+  p.add_argument(
+      "--ds-name",
+      default="VictoriaMetrics-ops",
+      help="Datasource name to set as current (default: VictoriaMetrics-ops)")
+  p.add_argument("--var-name",
+                 default="DS_PROMETHEUS",
+                 help="Dashboard variable name (default: DS_PROMETHEUS)")
+  mode = p.add_mutually_exclusive_group()
+  mode.add_argument(
+      "--prom-only",
+      action="store_true",
+      help=
+      'Only rewrite datasource OBJECTS with type=="prometheus"; leave STRING values untouched (conservative)'
+  )
+  mode.add_argument(
+      "--all-sources",
+      action="store_true",
+      help=
+      "Rewrite both OBJECT and STRING datasource fields (except Grafana internal annotations)"
+  )
+  p.add_argument("--dry-run",
+                 action="store_true",
+                 help="Do not write files, just print what would be done")
+  return p.parse_args()
+
 
 def iter_input_files(paths: List[str], pattern: str) -> List[Path]:
-    files: List[Path] = []
-    for p in paths:
-        path = Path(p)
-        if path.is_file():
-            files.append(path)
-        elif path.is_dir():
-            for f in path.rglob(pattern):
-                if f.is_file():
-                    files.append(f)
-        else:
-            print(f"⚠️  Not found: {path}", file=sys.stderr)
-    return files
+  files: List[Path] = []
+  for p in paths:
+    path = Path(p)
+    if path.is_file():
+      files.append(path)
+    elif path.is_dir():
+      for f in path.rglob(pattern):
+        if f.is_file():
+          files.append(f)
+    else:
+      print(f"⚠️  Not found: {path}", file=sys.stderr)
+  return files
+
 
 def unwrap_dashboard_root(data: Any) -> Any:
-    # Some exports wrap {"dashboard": {...}, "meta": {...}}; unwrap to the "dashboard" content.
-    if isinstance(data, dict) and "dashboard" in data and isinstance(data["dashboard"], dict):
-        return data["dashboard"]
-    return data
+  # Some exports wrap {"dashboard": {...}, "meta": {...}}; unwrap to the "dashboard" content.
+  if isinstance(data, dict) and "dashboard" in data and isinstance(
+      data["dashboard"], dict):
+    return data["dashboard"]
+  return data
+
 
 def ensure_ds_variable(d: Dict[str, Any], var_name: str, ds_name: str) -> None:
-    d.setdefault("templating", {})
-    if not isinstance(d["templating"], dict):
-        d["templating"] = {}
-    d["templating"].setdefault("list", [])
-    if not isinstance(d["templating"]["list"], list):
-        d["templating"]["list"] = []
+  d.setdefault("templating", {})
+  if not isinstance(d["templating"], dict):
+    d["templating"] = {}
+  d["templating"].setdefault("list", [])
+  if not isinstance(d["templating"]["list"], list):
+    d["templating"]["list"] = []
 
-    ds_var = {
-        "type": "datasource",
-        "name": var_name,
-        "label": "Datasource",
-        "query": "prometheus",
-        "current": {"text": ds_name, "value": ds_name, "selected": True},
-        "hide": 2
-    }
+  ds_var = {
+      "type": "datasource",
+      "name": var_name,
+      "label": "Datasource",
+      "query": "prometheus",
+      "current": {
+          "text": ds_name,
+          "value": ds_name,
+          "selected": True
+      },
+      "hide": 2
+  }
 
-    # Replace if an existing var with same name & type exists; else append
-    replaced = False
-    for i, var in enumerate(d["templating"]["list"]):
-        if isinstance(var, dict) and var.get("type") == "datasource" and var.get("name") == var_name:
-            d["templating"]["list"][i] = ds_var
-            replaced = True
-            break
-    if not replaced:
-        d["templating"]["list"].append(ds_var)
+  # Replace if an existing var with same name & type exists; else append
+  replaced = False
+  for i, var in enumerate(d["templating"]["list"]):
+    if isinstance(var, dict) and var.get("type") == "datasource" and var.get(
+        "name") == var_name:
+      d["templating"]["list"][i] = ds_var
+      replaced = True
+      break
+  if not replaced:
+    d["templating"]["list"].append(ds_var)
+
 
 def is_annotation_ds(obj: Any) -> bool:
-    # Grafana built-in annotation datasource looks like {"type":"datasource","uid":"grafana"}
-    return isinstance(obj, dict) and obj.get("type") == "datasource"
+  # Grafana built-in annotation datasource looks like {"type":"datasource","uid":"grafana"}
+  return isinstance(obj, dict) and obj.get("type") == "datasource"
 
-def rewrite_datasources(node: Any, var_name: str, prom_only: bool, rewrite_strings: bool) -> Any:
-    """
+
+def rewrite_datasources(node: Any, var_name: str, prom_only: bool,
+                        rewrite_strings: bool) -> Any:
+  """
     Recursively rewrite panel/target "datasource" fields to "${VAR_NAME}".
     - Skip Grafana internal annotation datasource objects.
     - If prom_only is True: only rewrite OBJECT datasources where .type == "prometheus".
       (STRING datasources left as-is unless rewrite_strings is True.)
     - If prom_only is False: rewrite all OBJECT datasources except annotations. STRINGs based on rewrite_strings.
     """
-    if isinstance(node, dict):
-        new_node = {}
-        for k, v in node.items():
-            if k == "datasource":
-                # Determine what to do based on value type
-                if is_annotation_ds(v):
-                    # leave annotation datasources untouched
-                    new_node[k] = v
-                elif isinstance(v, dict):
-                    if prom_only:
-                        if v.get("type") == "prometheus":
-                            new_node[k] = f"${{{var_name}}}"
-                        else:
-                            new_node[k] = v
-                    else:
-                        # rewrite any non-annotation object
-                        new_node[k] = f"${{{var_name}}}"
-                elif isinstance(v, str):
-                    if rewrite_strings:
-                        new_node[k] = f"${{{var_name}}}"
-                    else:
-                        new_node[k] = v
-                else:
-                    new_node[k] = v
+  if isinstance(node, dict):
+    new_node = {}
+    for k, v in node.items():
+      if k == "datasource":
+        # Determine what to do based on value type
+        if is_annotation_ds(v):
+          # leave annotation datasources untouched
+          new_node[k] = v
+        elif isinstance(v, dict):
+          if prom_only:
+            if v.get("type") == "prometheus":
+              new_node[k] = f"${{{var_name}}}"
             else:
-                new_node[k] = rewrite_datasources(v, var_name, prom_only, rewrite_strings)
-        return new_node
-    elif isinstance(node, list):
-        return [rewrite_datasources(x, var_name, prom_only, rewrite_strings) for x in node]
-    else:
-        return node
+              new_node[k] = v
+          else:
+            # rewrite any non-annotation object
+            new_node[k] = f"${{{var_name}}}"
+        elif isinstance(v, str):
+          if rewrite_strings:
+            new_node[k] = f"${{{var_name}}}"
+          else:
+            new_node[k] = v
+        else:
+          new_node[k] = v
+      else:
+        new_node[k] = rewrite_datasources(v, var_name, prom_only,
+                                          rewrite_strings)
+    return new_node
+  elif isinstance(node, list):
+    return [
+        rewrite_datasources(x, var_name, prom_only, rewrite_strings)
+        for x in node
+    ]
+  else:
+    return node
 
-def process_file(path: Path, outdir: Union[Path, None], in_place: bool, var_name: str, ds_name: str,
-                 prom_only: bool, all_sources: bool, dry_run: bool) -> Union[Path, None]:
-    try:
-        raw = path.read_text(encoding="utf-8")
-        data = json.loads(raw)
-    except Exception as e:
-        print(f"❌ Failed to read/parse {path}: {e}", file=sys.stderr)
-        return None
 
-    # 1) Unwrap {"dashboard": {...}, "meta": {...}} to just {...}
-    dash = unwrap_dashboard_root(data)
+def process_file(path: Path, outdir: Union[Path, None], in_place: bool,
+                 var_name: str, ds_name: str, prom_only: bool,
+                 all_sources: bool, dry_run: bool) -> Union[Path, None]:
+  try:
+    raw = path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+  except Exception as e:
+    print(f"❌ Failed to read/parse {path}: {e}", file=sys.stderr)
+    return None
 
-    # 2) Ensure templating variable
-    ensure_ds_variable(dash, var_name=var_name, ds_name=ds_name)
+  # 1) Unwrap {"dashboard": {...}, "meta": {...}} to just {...}
+  dash = unwrap_dashboard_root(data)
 
-    # 3) Rewrite datasources
-    rewrite_strings = all_sources  # only rewrite strings when --all-sources is used
-    dash = rewrite_datasources(dash, var_name=var_name, prom_only=prom_only, rewrite_strings=rewrite_strings)
+  # 2) Ensure templating variable
+  ensure_ds_variable(dash, var_name=var_name, ds_name=ds_name)
 
-    # Decide output path
-    if in_place:
-        out_path = path
-    elif outdir:
-        rel = path.name if path.is_file() else path.as_posix()
-        out_path = Path(outdir) / Path(rel).name
-    else:
-        out_path = path.with_name(path.stem + "_reworked.json")
+  # 3) Rewrite datasources
+  rewrite_strings = all_sources  # only rewrite strings when --all-sources is used
+  dash = rewrite_datasources(dash,
+                             var_name=var_name,
+                             prom_only=prom_only,
+                             rewrite_strings=rewrite_strings)
 
-    if dry_run:
-        print(f"DRY-RUN would write: {out_path}")
-        return out_path
+  # Decide output path
+  if in_place:
+    out_path = path
+  elif outdir:
+    rel = path.name if path.is_file() else path.as_posix()
+    out_path = Path(outdir) / Path(rel).name
+  else:
+    out_path = path.with_name(path.stem + "_reworked.json")
 
-    try:
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(json.dumps(dash, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-        print(f"✅ Wrote {out_path}")
-        return out_path
-    except Exception as e:
-        print(f"❌ Failed to write {out_path}: {e}", file=sys.stderr)
-        return None
+  if dry_run:
+    print(f"DRY-RUN would write: {out_path}")
+    return out_path
+
+  try:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(dash, indent=2, ensure_ascii=False) + "\n",
+                        encoding="utf-8")
+    print(f"✅ Wrote {out_path}")
+    return out_path
+  except Exception as e:
+    print(f"❌ Failed to write {out_path}: {e}", file=sys.stderr)
+    return None
+
 
 def main():
-    args = parse_args()
-    files = iter_input_files(args.inputs, args.glob)
-    if not files:
-        print("No files found.", file=sys.stderr)
-        sys.exit(2)
+  args = parse_args()
+  files = iter_input_files(args.inputs, args.glob)
+  if not files:
+    print("No files found.", file=sys.stderr)
+    sys.exit(2)
 
-    for f in files:
-        process_file(
-            path=f,
-            outdir=Path(args.output_dir) if args.output_dir else None,
-            in_place=args.in_place,
-            var_name=args.var_name,
-            ds_name=args.ds_name,
-            prom_only=args.prom_only,
-            all_sources=args.all_sources,
-            dry_run=args.dry_run,
-        )
+  for f in files:
+    process_file(
+        path=f,
+        outdir=Path(args.output_dir) if args.output_dir else None,
+        in_place=args.in_place,
+        var_name=args.var_name,
+        ds_name=args.ds_name,
+        prom_only=args.prom_only,
+        all_sources=args.all_sources,
+        dry_run=args.dry_run,
+    )
+
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/status-page-sync.sh
+++ b/status-page-sync.sh
@@ -12,8 +12,8 @@ FOLDER=dashboard-result
 mkdir -p "$FOLDER"
 
 curl -s "https://${GRAFANA_AUTH}@${GRAFANA_URL}/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards?limit=1" \
-| jq -c '.items[] | {title: .spec.title, spec: .spec}' \
-| while IFS= read -r dash; do
+  | jq -c '.items[] | {title: .spec.title, spec: .spec}' \
+  | while IFS= read -r dash; do
     title=$(echo "$dash" | jq -r '.title' | sed 's/ /-/g')
     echo "$dash" | jq '.spec' > "$FOLDER/$title.json"
   done

--- a/sync-status-page.py
+++ b/sync-status-page.py
@@ -17,10 +17,8 @@ load_dotenv()
 
 # ---- Logging (stderr) ----
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
-logging.basicConfig(
-    level=getattr(logging, LOG_LEVEL, logging.INFO),
-    format="%(asctime)s %(levelname)s %(message)s"
-)
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO),
+                    format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("spm-checker")
 
 # ---- API config / Type & attribute names ----
@@ -29,19 +27,25 @@ TOKEN = os.getenv("INCIDENT_API_TOKEN")
 
 # Alertmanager config (only used when count > 0, or if you choose to resolve)
 ALERTMANAGER_ENABLE = os.getenv("ALERTMANAGER_ENABLE", "true")
-ALERTMANAGER_URL = os.getenv("ALERTMANAGER_URL", "http://vmalertmanager-vmks-victoria-metrics-k8s-stack.monitoring.svc")
+ALERTMANAGER_URL = os.getenv(
+    "ALERTMANAGER_URL",
+    "http://vmalertmanager-vmks-victoria-metrics-k8s-stack.monitoring.svc")
 ALERTMANAGER_ROUTE = os.getenv("ALERTMANAGER_ROUTE", "/api/v2/alerts")
 ALERTMANAGER_TIMEOUT = float(os.getenv("ALERTMANAGER_TIMEOUT", "10"))
-ALERTMANAGER_ALERTNAME = os.getenv("ALERTMANAGER_ALERTNAME", "IncidentStatusPageMapDrift")
+ALERTMANAGER_ALERTNAME = os.getenv("ALERTMANAGER_ALERTNAME",
+                                   "IncidentStatusPageMapDrift")
 ALERTMANAGER_SEVERITY = os.getenv("ALERTMANAGER_SEVERITY", "warning")
-ALERTMANAGER_COMPONENT_LABEL = os.getenv("ALERTMANAGER_COMPONENT_LABEL", "monitoring")
-ALERTMANAGER_EXTRA_LABELS_JSON = os.getenv("ALERTMANAGER_EXTRA_LABELS_JSON", "")  # e.g. {"env":"prod"}
+ALERTMANAGER_COMPONENT_LABEL = os.getenv("ALERTMANAGER_COMPONENT_LABEL",
+                                         "monitoring")
+ALERTMANAGER_EXTRA_LABELS_JSON = os.getenv("ALERTMANAGER_EXTRA_LABELS_JSON",
+                                           "")  # e.g. {"env":"prod"}
 
 # Logical type names — case-insensitive.
 TYPE_NAMES = {
     "component": os.getenv("COMPONENT_TYPE_NAME", "Component"),
-    "network":   os.getenv("NETWORK_TYPE_NAME", "Network"),
-    "spm":       os.getenv("SPM_TYPE_NAME", "Status Page Map"),  # default adapted to your schema
+    "network": os.getenv("NETWORK_TYPE_NAME", "Network"),
+    "spm": os.getenv("SPM_TYPE_NAME",
+                     "Status Page Map"),  # default adapted to your schema
 }
 
 # Attribute names/IDs — matched by name (case-insensitive) or by exact id.
@@ -50,14 +54,17 @@ TYPE_NAMES = {
 #  - SPM.component      -> name "Component associated"
 #  - SPM.network        -> name "Network associated"
 ATTR_NAMES = {
-    "component_networks": os.getenv("COMPONENT_NETWORKS_ATTR_NAME", "Networks supported"),
-    "spm_component": os.getenv("SPM_COMPONENT_ATTR_NAME", "Component associated"),
-    "spm_network":   os.getenv("SPM_NETWORK_ATTR_NAME", "Network associated"),
+    "component_networks":
+    os.getenv("COMPONENT_NETWORKS_ATTR_NAME", "Networks supported"),
+    "spm_component":
+    os.getenv("SPM_COMPONENT_ATTR_NAME", "Component associated"),
+    "spm_network":
+    os.getenv("SPM_NETWORK_ATTR_NAME", "Network associated"),
 }
 
 if not TOKEN:
-    print("Missing INCIDENT_API_TOKEN", file=sys.stderr)
-    sys.exit(2)
+  print("Missing INCIDENT_API_TOKEN", file=sys.stderr)
+  sys.exit(2)
 
 S = requests.Session()
 S.headers.update({"Authorization": f"Bearer {TOKEN}"})
@@ -67,105 +74,112 @@ S.headers.update({"Authorization": f"Bearer {TOKEN}"})
 # incident.io API helpers
 # =======================
 def list_types():
-    r = S.get(f"{BASE}/v3/catalog_types", timeout=30)
-    r.raise_for_status()
-    return r.json()["catalog_types"]
+  r = S.get(f"{BASE}/v3/catalog_types", timeout=30)
+  r.raise_for_status()
+  return r.json()["catalog_types"]
+
 
 def find_type(types, name):
-    for t in types:
-        if (t.get("name","") or "").lower() == name.lower():
-            return t
-    raise RuntimeError(f"Catalog type not found: {name}")
+  for t in types:
+    if (t.get("name", "") or "").lower() == name.lower():
+      return t
+  raise RuntimeError(f"Catalog type not found: {name}")
+
 
 def attr_id_by_name_or_id(cat_type, key):
-    """
+  """
     Return (attribute_id, attribute_object) matching either by name (case-insensitive)
     or by exact id if 'key' looks like an id.
     """
-    attrs = cat_type.get("schema",{}).get("attributes",[])
-    # 1) Try by exact id
-    for a in attrs:
-        if key == a.get("id"):
-            return a["id"], a
-    # 2) Try by name (case-insensitive)
-    key_low = (key or "").lower()
-    for a in attrs:
-        if (a.get("name","") or "").lower() == key_low:
-            return a["id"], a
-    # 3) Nothing found
-    raise RuntimeError(f"Attribute not found on type '{cat_type.get('name')}': {key}")
+  attrs = cat_type.get("schema", {}).get("attributes", [])
+  # 1) Try by exact id
+  for a in attrs:
+    if key == a.get("id"):
+      return a["id"], a
+  # 2) Try by name (case-insensitive)
+  key_low = (key or "").lower()
+  for a in attrs:
+    if (a.get("name", "") or "").lower() == key_low:
+      return a["id"], a
+  # 3) Nothing found
+  raise RuntimeError(
+      f"Attribute not found on type '{cat_type.get('name')}': {key}")
+
 
 def paginate_entries(catalog_type_id):
-    after = None
-    while True:
-        params = {"catalog_type_id": catalog_type_id, "page_size": 250}
-        if after:
-            params["after"] = after
-        r = S.get(f"{BASE}/v3/catalog_entries", params=params, timeout=60)
-        r.raise_for_status()
-        data = r.json()
-        for e in data.get("catalog_entries", []):
-            yield e
-        after = data.get("pagination_meta", {}).get("after")
-        if not after:
-            break
+  after = None
+  while True:
+    params = {"catalog_type_id": catalog_type_id, "page_size": 250}
+    if after:
+      params["after"] = after
+    r = S.get(f"{BASE}/v3/catalog_entries", params=params, timeout=60)
+    r.raise_for_status()
+    data = r.json()
+    for e in data.get("catalog_entries", []):
+      yield e
+    after = data.get("pagination_meta", {}).get("after")
+    if not after:
+      break
+
 
 def show_entry(entry_id):
-    r = S.get(f"{BASE}/v3/catalog_entries/{entry_id}", timeout=30)
-    r.raise_for_status()
-    return r.json()["catalog_entry"]
+  r = S.get(f"{BASE}/v3/catalog_entries/{entry_id}", timeout=30)
+  r.raise_for_status()
+  return r.json()["catalog_entry"]
 
 
 # ===========================================
 # Helpers for resolving & extracting values
 # ===========================================
 def build_extindex(catalog_type_id):
-    """
+  """
     Build an index external_id -> (id, name) for a given type.
     Useful to resolve Custom[...] attributes (value.literal = external_id).
     """
-    idx = {}
-    count = 0
-    for e in paginate_entries(catalog_type_id):
-        count += 1
-        ext = e.get("external_id")
-        if ext:
-            idx[ext] = (e["id"], e.get("name") or ext)
-    logger.info("Index built for type %s (entries=%d, external_ids=%d)",
-                catalog_type_id, count, len(idx))
-    return idx
+  idx = {}
+  count = 0
+  for e in paginate_entries(catalog_type_id):
+    count += 1
+    ext = e.get("external_id")
+    if ext:
+      idx[ext] = (e["id"], e.get("name") or ext)
+  logger.info("Index built for type %s (entries=%d, external_ids=%d)",
+              catalog_type_id, count, len(idx))
+  return idx
+
 
 def extract_single_custom(attr_value_obj, ext_index=None):
-    """
+  """
     Supports two formats:
       - Custom[...] format (current V3): value.literal (= external_id) and value.label
       - Relational 'catalog_entry' format (legacy / client library)
     Returns: (id, name) if resolved, otherwise (None, label/literal) for diagnostics.
     """
-    if not attr_value_obj:
-        return (None, None)
-    v = attr_value_obj.get("value") or {}
+  if not attr_value_obj:
+    return (None, None)
+  v = attr_value_obj.get("value") or {}
 
-    # Custom[...] format: external_id in 'literal'
-    lit = v.get("literal")
-    if lit is not None:
-        if ext_index:
-            rid, rname = ext_index.get(lit, (None, v.get("label") or lit))
-            return (rid, rname)
-        return (None, v.get("label") or lit)
+  # Custom[...] format: external_id in 'literal'
+  lit = v.get("literal")
+  if lit is not None:
+    if ext_index:
+      rid, rname = ext_index.get(lit, (None, v.get("label") or lit))
+      return (rid, rname)
+    return (None, v.get("label") or lit)
 
-    # Legacy format: catalog_entry object
-    ce = v.get("catalog_entry") or {}
-    rid = ce.get("catalog_entry_id")
-    rname = ce.get("catalog_entry_name")
-    if rid:
-        return (rid, rname)
+  # Legacy format: catalog_entry object
+  ce = v.get("catalog_entry") or {}
+  rid = ce.get("catalog_entry_id")
+  rname = ce.get("catalog_entry_name")
+  if rid:
+    return (rid, rname)
 
-    # Last resort: label
-    return (None, v.get("label"))
+  # Last resort: label
+  return (None, v.get("label"))
+
 
 def extract_array_custom(attr_value_obj, ext_index=None):
-    """
+  """
     Handle 'array' attributes containing Custom[...] references to catalog entries.
     Supports:
       - array_value: [ {"label":"...","literal":"..."} ]              # flat format
@@ -176,280 +190,293 @@ def extract_array_custom(attr_value_obj, ext_index=None):
       - name will be the label (or literal) if not resolved
       - external_id_or_none is useful for logging/diagnostics
     """
-    out = []
-    if not attr_value_obj:
-        return out
-
-    arr = attr_value_obj.get("array_value")
-    if isinstance(arr, list) and arr:
-        for item in arr:
-            if not isinstance(item, dict):
-                continue
-
-            # --- Flat format: {label, literal}
-            if "literal" in item or "label" in item:
-                lit = item.get("literal")
-                lab = item.get("label")
-                if lit is not None:
-                    if ext_index:
-                        rid, rname = ext_index.get(lit, (None, lab or lit))
-                        out.append((rid, rname, lit))
-                    else:
-                        out.append((None, lab or lit, lit))
-                else:
-                    out.append((None, lab, None))
-                continue
-
-            # --- Format with 'value': {...}
-            v = (item or {}).get("value") or {}
-
-            # 2.1) Custom[...] via literal/label
-            lit = v.get("literal")
-            if lit is not None:
-                lab = v.get("label") or lit
-                if ext_index:
-                    rid, rname = ext_index.get(lit, (None, lab))
-                    out.append((rid, rname, lit))
-                else:
-                    out.append((None, lab, lit))
-                continue
-
-            # 2.2) Legacy relational format via catalog_entry
-            ce = v.get("catalog_entry") or {}
-            rid = ce.get("catalog_entry_id")
-            rname = ce.get("catalog_entry_name")
-            if rid or rname:
-                out.append((rid, rname, None))
-
-    # Fallback if the API returns a simple value instead of an array
-    if not out:
-        rid, rname = extract_single_custom(attr_value_obj, ext_index)
-        if rid or rname:
-            out.append((rid, rname, None))
-
+  out = []
+  if not attr_value_obj:
     return out
+
+  arr = attr_value_obj.get("array_value")
+  if isinstance(arr, list) and arr:
+    for item in arr:
+      if not isinstance(item, dict):
+        continue
+
+      # --- Flat format: {label, literal}
+      if "literal" in item or "label" in item:
+        lit = item.get("literal")
+        lab = item.get("label")
+        if lit is not None:
+          if ext_index:
+            rid, rname = ext_index.get(lit, (None, lab or lit))
+            out.append((rid, rname, lit))
+          else:
+            out.append((None, lab or lit, lit))
+        else:
+          out.append((None, lab, None))
+        continue
+
+      # --- Format with 'value': {...}
+      v = (item or {}).get("value") or {}
+
+      # 2.1) Custom[...] via literal/label
+      lit = v.get("literal")
+      if lit is not None:
+        lab = v.get("label") or lit
+        if ext_index:
+          rid, rname = ext_index.get(lit, (None, lab))
+          out.append((rid, rname, lit))
+        else:
+          out.append((None, lab, lit))
+        continue
+
+      # 2.2) Legacy relational format via catalog_entry
+      ce = v.get("catalog_entry") or {}
+      rid = ce.get("catalog_entry_id")
+      rname = ce.get("catalog_entry_name")
+      if rid or rname:
+        out.append((rid, rname, None))
+
+  # Fallback if the API returns a simple value instead of an array
+  if not out:
+    rid, rname = extract_single_custom(attr_value_obj, ext_index)
+    if rid or rname:
+      out.append((rid, rname, None))
+
+  return out
 
 
 # ===========================================
 # Alertmanager — send alert
 # ===========================================
 def send_alert_to_alertmanager(diff_count, missing):
-    """
+  """
     Send an alert to Alertmanager (POST /api/v2/alerts) describing the drift.
     Called only when diff_count > 0.
     """
-    if not ALERTMANAGER_URL:
-        logger.info("ALERTMANAGER_URL is not set — skipping Alertmanager POST.")
-        return
+  if not ALERTMANAGER_URL:
+    logger.info("ALERTMANAGER_URL is not set — skipping Alertmanager POST.")
+    return
 
-    labels = {
-        "alertname": ALERTMANAGER_ALERTNAME,
-        "severity": ALERTMANAGER_SEVERITY,
-        "component": ALERTMANAGER_COMPONENT_LABEL,
-    }
-    # Optional extra labels as JSON
-    if ALERTMANAGER_EXTRA_LABELS_JSON:
-        try:
-            labels.update(json.loads(ALERTMANAGER_EXTRA_LABELS_JSON))
-        except Exception as e:
-            logger.warning("ALERTMANAGER_EXTRA_LABELS_JSON invalid JSON: %s", e)
-
-    # Compose a readable preview list (limited)
-    MAX_LINES = int(os.getenv("ALERTMANAGER_ANNOTATION_MAX_LINES", "20"))
-    lines = []
-    for i, m in enumerate(missing[:MAX_LINES], start=1):
-        comp = f'{m.get("component_name") or m.get("component_id")}'
-        net  = f'{m.get("network_name") or m.get("network_id")}'
-        lines.append(f"{i}. {comp} ↔ {net}")
-    if len(missing) > MAX_LINES:
-        lines.append(f"... (+{len(missing)-MAX_LINES} more)")
-
-    annotations = {
-        "summary": f"{diff_count} Status Page Map mapping(s) missing",
-        "description": "\n".join(lines) if lines else "No details",
-    }
-    alert = {
-        "labels": labels,
-        "annotations": annotations,
-        "startsAt": datetime.now(timezone.utc).isoformat(),
-    }
-
-    url = ALERTMANAGER_URL.rstrip("/") + ALERTMANAGER_ROUTE
-    headers = {"Content-Type": "application/json"}
-
+  labels = {
+      "alertname": ALERTMANAGER_ALERTNAME,
+      "severity": ALERTMANAGER_SEVERITY,
+      "component": ALERTMANAGER_COMPONENT_LABEL,
+  }
+  # Optional extra labels as JSON
+  if ALERTMANAGER_EXTRA_LABELS_JSON:
     try:
-        r = requests.post(
-            url, json=[alert], headers=headers,
-            timeout=ALERTMANAGER_TIMEOUT, verify="false"
-        )
-        if r.status_code >= 300:
-            logger.error("Alertmanager POST %s -> %s: %s", url, r.status_code, r.text[:500])
-        else:
-            logger.info("Alert sent to Alertmanager (%s)", url)
+      labels.update(json.loads(ALERTMANAGER_EXTRA_LABELS_JSON))
     except Exception as e:
-        logger.exception("Failed to POST to Alertmanager: %s", e)
+      logger.warning("ALERTMANAGER_EXTRA_LABELS_JSON invalid JSON: %s", e)
+
+  # Compose a readable preview list (limited)
+  MAX_LINES = int(os.getenv("ALERTMANAGER_ANNOTATION_MAX_LINES", "20"))
+  lines = []
+  for i, m in enumerate(missing[:MAX_LINES], start=1):
+    comp = f'{m.get("component_name") or m.get("component_id")}'
+    net = f'{m.get("network_name") or m.get("network_id")}'
+    lines.append(f"{i}. {comp} ↔ {net}")
+  if len(missing) > MAX_LINES:
+    lines.append(f"... (+{len(missing)-MAX_LINES} more)")
+
+  annotations = {
+      "summary": f"{diff_count} Status Page Map mapping(s) missing",
+      "description": "\n".join(lines) if lines else "No details",
+  }
+  alert = {
+      "labels": labels,
+      "annotations": annotations,
+      "startsAt": datetime.now(timezone.utc).isoformat(),
+  }
+
+  url = ALERTMANAGER_URL.rstrip("/") + ALERTMANAGER_ROUTE
+  headers = {"Content-Type": "application/json"}
+
+  try:
+    r = requests.post(url,
+                      json=[alert],
+                      headers=headers,
+                      timeout=ALERTMANAGER_TIMEOUT,
+                      verify="false")
+    if r.status_code >= 300:
+      logger.error("Alertmanager POST %s -> %s: %s", url, r.status_code,
+                   r.text[:500])
+    else:
+      logger.info("Alert sent to Alertmanager (%s)", url)
+  except Exception as e:
+    logger.exception("Failed to POST to Alertmanager: %s", e)
 
 
 # =========
 # Program
 # =========
 def main():
-    # 1) Resolve types & attributes
-    types = list_types()
-    t_component = find_type(types, TYPE_NAMES["component"])
-    t_network   = find_type(types, TYPE_NAMES["network"])
-    t_spm       = find_type(types, TYPE_NAMES["spm"])
+  # 1) Resolve types & attributes
+  types = list_types()
+  t_component = find_type(types, TYPE_NAMES["component"])
+  t_network = find_type(types, TYPE_NAMES["network"])
+  t_spm = find_type(types, TYPE_NAMES["spm"])
 
-    comp_networks_attr_id, _ = attr_id_by_name_or_id(t_component, ATTR_NAMES["component_networks"])
-    spm_component_attr_id, _ = attr_id_by_name_or_id(t_spm, ATTR_NAMES["spm_component"])
-    spm_network_attr_id, _   = attr_id_by_name_or_id(t_spm, ATTR_NAMES["spm_network"])
+  comp_networks_attr_id, _ = attr_id_by_name_or_id(
+      t_component, ATTR_NAMES["component_networks"])
+  spm_component_attr_id, _ = attr_id_by_name_or_id(t_spm,
+                                                   ATTR_NAMES["spm_component"])
+  spm_network_attr_id, _ = attr_id_by_name_or_id(t_spm,
+                                                 ATTR_NAMES["spm_network"])
 
-    # 2) Index external_id -> (id, name) for Component & Network
-    idx_component = build_extindex(t_component["id"])
-    idx_network   = build_extindex(t_network["id"])
+  # 2) Index external_id -> (id, name) for Component & Network
+  idx_component = build_extindex(t_component["id"])
+  idx_network = build_extindex(t_network["id"])
 
-    # 3) Read SPM entries: extract (component_id, network_id)
-    logger.info("Reading entries for 'Status page map' type...")
-    spm_pairs = defaultdict(set)  # comp_id -> set([network_id or None])
-    components_in_spm = set()
-    component_names = {}          # comp_id -> friendly name
-    count_spm = 0
+  # 3) Read SPM entries: extract (component_id, network_id)
+  logger.info("Reading entries for 'Status page map' type...")
+  spm_pairs = defaultdict(set)  # comp_id -> set([network_id or None])
+  components_in_spm = set()
+  component_names = {}  # comp_id -> friendly name
+  count_spm = 0
 
-    first_dump_done = False
+  first_dump_done = False
 
-    for spm in paginate_entries(t_spm["id"]):
-        count_spm += 1
-        av = spm.get("attribute_values", {}) or {}
+  for spm in paginate_entries(t_spm["id"]):
+    count_spm += 1
+    av = spm.get("attribute_values", {}) or {}
 
-        # Diagnostic dump (only once, in DEBUG)
-        if LOG_LEVEL == "DEBUG" and not first_dump_done:
-            logger.debug("Sample SPM attribute_values: %s", json.dumps(av, ensure_ascii=False))
-            first_dump_done = True
+    # Diagnostic dump (only once, in DEBUG)
+    if LOG_LEVEL == "DEBUG" and not first_dump_done:
+      logger.debug("Sample SPM attribute_values: %s",
+                   json.dumps(av, ensure_ascii=False))
+      first_dump_done = True
 
-        comp_id, comp_name = extract_single_custom(av.get(spm_component_attr_id), idx_component)
-        if not comp_id:
-            logger.warning(
-                "SPM '%s' without resolved component (value=%s). Verify that the Component external_id exists.",
-                spm.get("name"),
-                json.dumps((av.get(spm_component_attr_id) or {}).get("value"), ensure_ascii=False)
-            )
-            continue
+    comp_id, comp_name = extract_single_custom(av.get(spm_component_attr_id),
+                                               idx_component)
+    if not comp_id:
+      logger.warning(
+          "SPM '%s' without resolved component (value=%s). Verify that the Component external_id exists.",
+          spm.get("name"),
+          json.dumps((av.get(spm_component_attr_id) or {}).get("value"),
+                     ensure_ascii=False))
+      continue
 
-        if comp_name:
-            component_names[comp_id] = comp_name
-        components_in_spm.add(comp_id)
+    if comp_name:
+      component_names[comp_id] = comp_name
+    components_in_spm.add(comp_id)
 
-        net_id, _ = extract_single_custom(av.get(spm_network_attr_id), idx_network)
-        # net_id can be None if there is no network (expected case)
-        spm_pairs[comp_id].add(net_id)
+    net_id, _ = extract_single_custom(av.get(spm_network_attr_id), idx_network)
+    # net_id can be None if there is no network (expected case)
+    spm_pairs[comp_id].add(net_id)
 
-    # LOG #1 — Components extracted from SPM
-    comp_list_for_log = [
-        {"component_id": cid, "component_name": component_names.get(cid)}
-        for cid in sorted(components_in_spm)
-    ]
-    logger.info("Components extracted from Status page map (total=%d): %s",
-                len(comp_list_for_log), json.dumps(comp_list_for_log, ensure_ascii=False))
+  # LOG #1 — Components extracted from SPM
+  comp_list_for_log = [{
+      "component_id": cid,
+      "component_name": component_names.get(cid)
+  } for cid in sorted(components_in_spm)]
+  logger.info("Components extracted from Status page map (total=%d): %s",
+              len(comp_list_for_log),
+              json.dumps(comp_list_for_log, ensure_ascii=False))
 
-    # 4) For each component present in SPM, discover its actual networks
-    logger.info("Inspecting components to discover their networks...")
-    missing = []
-    comp_to_discovered_networks = {}  # comp_id -> [{"network_id":..., "network_name":..., "network_external_id":...}, ...]
-    unresolved_all = []               # for output JSON
+  # 4) For each component present in SPM, discover its actual networks
+  logger.info("Inspecting components to discover their networks...")
+  missing = []
+  comp_to_discovered_networks = {
+  }  # comp_id -> [{"network_id":..., "network_name":..., "network_external_id":...}, ...]
+  unresolved_all = []  # for output JSON
 
-    cache = {}
-    def get_component(entry_id):
-        if entry_id not in cache:
-            cache[entry_id] = show_entry(entry_id)
-        return cache[entry_id]
+  cache = {}
 
-    for comp_id in sorted(components_in_spm):
-        comp = get_component(comp_id)
-        comp_name = comp.get("name", comp_id)
-        component_names[comp_id] = component_names.get(comp_id) or comp_name
+  def get_component(entry_id):
+    if entry_id not in cache:
+      cache[entry_id] = show_entry(entry_id)
+    return cache[entry_id]
 
-        nets_attr = (comp.get("attribute_values", {}) or {}).get(comp_networks_attr_id)
-        nets = extract_array_custom(nets_attr, idx_network)  # list of (nid, nname, nlit)
+  for comp_id in sorted(components_in_spm):
+    comp = get_component(comp_id)
+    comp_name = comp.get("name", comp_id)
+    component_names[comp_id] = component_names.get(comp_id) or comp_name
 
-        unresolved = [(nlit or nname) for (nid, nname, nlit) in nets if not nid]
-        if unresolved:
-            logger.warning(
-                "Component '%s' (%s): %d/%d network(s) unresolved via external_id: %s",
-                comp_name, comp_id, len(unresolved), len(nets), ", ".join(unresolved)
-            )
-            for u in unresolved:
-                unresolved_all.append({
-                    "component_id": comp_id,
-                    "component_name": comp_name,
-                    "network_external_id": u
-                })
+    nets_attr = (comp.get("attribute_values", {})
+                 or {}).get(comp_networks_attr_id)
+    nets = extract_array_custom(nets_attr,
+                                idx_network)  # list of (nid, nname, nlit)
 
-        comp_to_discovered_networks[comp_id] = [
-            {
-                "network_id": nid,
-                "network_name": nname,
-                "network_external_id": nlit
-            }
-            for (nid, nname, nlit) in nets
-        ]
-
-        # If there is no network, skip verification (as requested)
-        if not nets:
-            continue
-
-        existing_nets = spm_pairs.get(comp_id, set())
-        for nid, nname, nlit in nets:
-            if not nid:
-                # Unresolved → already logged above
-                continue
-            if nid not in existing_nets:
-                missing.append({
-                    "component_id": comp_id,
-                    "component_name": comp_name,
-                    "network_id": nid,
-                    "network_name": nname,
-                })
-
-    # 5) Output & Alertmanager
-    diff_count = len(missing)
-
-    if diff_count == 0:
-        # As requested: only output the count when there is no difference
-        print(json.dumps({"count": 0}, indent=2, ensure_ascii=False))
-        return # exit the function
-
-    # LOG #2 — Networks discovered for each component
-    networks_log = []
-    for comp_id in sorted(components_in_spm):
-        networks_log.append({
+    unresolved = [(nlit or nname) for (nid, nname, nlit) in nets if not nid]
+    if unresolved:
+      logger.warning(
+          "Component '%s' (%s): %d/%d network(s) unresolved via external_id: %s",
+          comp_name, comp_id, len(unresolved), len(nets),
+          ", ".join(unresolved))
+      for u in unresolved:
+        unresolved_all.append({
             "component_id": comp_id,
-            "component_name": component_names.get(comp_id),
-            "networks": comp_to_discovered_networks.get(comp_id, [])
+            "component_name": comp_name,
+            "network_external_id": u
         })
-    logger.info("Networks discovered for each component referenced in SPM: %s",
-                json.dumps(networks_log, indent=2, ensure_ascii=False))
 
-    # Send alert to Alertmanager (only if configured)
-    if ALERTMANAGER_ENABLE == "true":
-        send_alert_to_alertmanager(diff_count, missing)
+    comp_to_discovered_networks[comp_id] = [{
+        "network_id": nid,
+        "network_name": nname,
+        "network_external_id": nlit
+    } for (nid, nname, nlit) in nets]
 
-    # Detailed JSON output when differences exist
-    result = {
-        "count": diff_count,
-        "missing_component_network_mappings": missing,
-        "unresolved_networks": unresolved_all,  # useful to fix inconsistent external_ids
-        "stats": {
-            "status_page_map_entries": sum(len(v) for v in spm_pairs.values()),
-            "unique_components_in_spm": len(components_in_spm),
-        }
-    }
-    print(json.dumps(result, indent=2, ensure_ascii=False))
+    # If there is no network, skip verification (as requested)
+    if not nets:
+      continue
+
+    existing_nets = spm_pairs.get(comp_id, set())
+    for nid, nname, nlit in nets:
+      if not nid:
+        # Unresolved → already logged above
+        continue
+      if nid not in existing_nets:
+        missing.append({
+            "component_id": comp_id,
+            "component_name": comp_name,
+            "network_id": nid,
+            "network_name": nname,
+        })
+
+  # 5) Output & Alertmanager
+  diff_count = len(missing)
+
+  if diff_count == 0:
+    # As requested: only output the count when there is no difference
+    print(json.dumps({"count": 0}, indent=2, ensure_ascii=False))
+    return  # exit the function
+
+  # LOG #2 — Networks discovered for each component
+  networks_log = []
+  for comp_id in sorted(components_in_spm):
+    networks_log.append({
+        "component_id":
+        comp_id,
+        "component_name":
+        component_names.get(comp_id),
+        "networks":
+        comp_to_discovered_networks.get(comp_id, [])
+    })
+  logger.info("Networks discovered for each component referenced in SPM: %s",
+              json.dumps(networks_log, indent=2, ensure_ascii=False))
+
+  # Send alert to Alertmanager (only if configured)
+  if ALERTMANAGER_ENABLE == "true":
+    send_alert_to_alertmanager(diff_count, missing)
+
+  # Detailed JSON output when differences exist
+  result = {
+      "count": diff_count,
+      "missing_component_network_mappings": missing,
+      "unresolved_networks":
+      unresolved_all,  # useful to fix inconsistent external_ids
+      "stats": {
+          "status_page_map_entries": sum(len(v) for v in spm_pairs.values()),
+          "unique_components_in_spm": len(components_in_spm),
+      }
+  }
+  print(json.dumps(result, indent=2, ensure_ascii=False))
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        logger.exception("Script failed")
-        print(f"ERROR: {e}", file=sys.stderr)
-        sys.exit(1)
+  try:
+    main()
+  except Exception as e:
+    logger.exception("Script failed")
+    print(f"ERROR: {e}", file=sys.stderr)
+    sys.exit(1)

--- a/test-alert.sh
+++ b/test-alert.sh
@@ -30,7 +30,7 @@ send_alert() {
   done
   labels_json+="}"
 
-  cat <<EOF | curl -s -X POST $url -H "Content-Type: application/json" -d @-
+  cat << EOF | curl -s -X POST $url -H "Content-Type: application/json" -d @-
 [
   {
     "status": "$status",

--- a/test-probe.sh
+++ b/test-probe.sh
@@ -24,27 +24,27 @@ URLS=(
 )
 
 # Ensure hey is available
-if ! command -v "$HEY_BIN" >/dev/null 2>&1; then
+if ! command -v "$HEY_BIN" > /dev/null 2>&1; then
   echo "❌ hey not found. Install it and/or set HEY_BIN." >&2
   exit 1
 fi
 
 while true; do
-    for url in "${URLS[@]}"; do
-      ts="$(date -Is)"
-      # Run hey (suppress the progress bar); capture output
-      out="$("$HEY_BIN" --disable-keepalive -n "$NREQ" -c "$CONCURRENCY" "$url" 2>&1 || true)"
+  for url in "${URLS[@]}"; do
+    ts="$(date -Is)"
+    # Run hey (suppress the progress bar); capture output
+    out="$("$HEY_BIN" --disable-keepalive -n "$NREQ" -c "$CONCURRENCY" "$url" 2>&1 || true)"
 
-      # Parse the HTTP status code distribution
-      # Grab lines from the "Status code distribution:" block
-      status_block="$(printf "%s\n" "$out" \
-        | awk '/Status code distribution:/{f=1;print;next} f&&/^[[:space:]]*\[[0-9]{3}\]/{print} f&&!/^[[:space:]]*\[[0-9]{3}\]/{ if(NR>1) exit }')"
+    # Parse the HTTP status code distribution
+    # Grab lines from the "Status code distribution:" block
+    status_block="$(printf "%s\n" "$out" \
+      | awk '/Status code distribution:/{f=1;print;next} f&&/^[[:space:]]*\[[0-9]{3}\]/{print} f&&!/^[[:space:]]*\[[0-9]{3}\]/{ if(NR>1) exit }')"
 
-      total=0
-      ok200=0
+    total=0
+    ok200=0
 
-      # Extract "  [200] 12 responses" => code=200, cnt=12
-      while read -r code cnt _; do
+    # Extract "  [200] 12 responses" => code=200, cnt=12
+    while read -r code cnt _; do
       [[ -z "${code:-}" ]] && continue
       # code format "[200]"
       code="${code#[}"
@@ -57,21 +57,21 @@ while true; do
       fi
     done < <(printf "%s\n" "$status_block" | sed -n 's/^[[:space:]]*\[\([0-9]\{3\}\)\][[:space:]]*\([0-9]\+\).*/[\1] \2/p')
 
-      # If parsing failed, treat as an error
-      if [[ "$total" -eq 0 ]]; then
-        echo "[$ts] ❌ $url → unable to validate responses (hey may have failed)"
-        printf "%s\n" "$out" | sed -n '1,120p' >&2
-      elif [[ "$ok200" -eq "$total" ]]; then
-        echo "[$ts] ✅ $url → OK (all $ok200/$total responses are 200)"
-      else
-        echo "[$ts] ⚠️  $url → WARNING (non-200 codes detected: $((total-ok200))/$total)"
-        # Show relevant snippet
-        printf "%s\n" "$status_block"
-        # If present, display the error block from hey
-        err_block="$(printf "%s\n" "$out" | awk '/Error distribution:/{f=1;print;next} f&&/^[[:space:]]*\[[0-9]+\]/{print} f&&!/^[[:space:]]*\[[0-9]+\]/{ if(NR>1) exit }')"
-        [[ -n "$err_block" ]] && printf "%s\n" "$err_block"
-      fi
+    # If parsing failed, treat as an error
+    if [[ "$total" -eq 0 ]]; then
+      echo "[$ts] ❌ $url → unable to validate responses (hey may have failed)"
+      printf "%s\n" "$out" | sed -n '1,120p' >&2
+    elif [[ "$ok200" -eq "$total" ]]; then
+      echo "[$ts] ✅ $url → OK (all $ok200/$total responses are 200)"
+    else
+      echo "[$ts] ⚠️  $url → WARNING (non-200 codes detected: $((total - ok200))/$total)"
+      # Show relevant snippet
+      printf "%s\n" "$status_block"
+      # If present, display the error block from hey
+      err_block="$(printf "%s\n" "$out" | awk '/Error distribution:/{f=1;print;next} f&&/^[[:space:]]*\[[0-9]+\]/{print} f&&!/^[[:space:]]*\[[0-9]+\]/{ if(NR>1) exit }')"
+      [[ -n "$err_block" ]] && printf "%s\n" "$err_block"
+    fi
 
-      sleep "$SLEEP_SEC"
+    sleep "$SLEEP_SEC"
   done
 done

--- a/update-sops.sh
+++ b/update-sops.sh
@@ -8,8 +8,8 @@ DIR=$(pwd)
 echo "running from $DIR"
 shopt -s nullglob
 find . -type f \( -name "*.enc" -o -name "*.env" \) | while read -r file; do
-    echo "Updating: $file"
-    cd $(dirname "$file")
-    sops updatekeys $(basename "$file") -y
-    cd $DIR
+  echo "Updating: $file"
+  cd $(dirname "$file")
+  sops updatekeys $(basename "$file") -y
+  cd $DIR
 done

--- a/update_readme.py
+++ b/update_readme.py
@@ -16,55 +16,56 @@ README_HEADER = "# utils\nUseful scripts collection built along the journey\n"
 
 
 def extract_description(path: Path) -> str:
-    """Return the standardized description block for the script."""
-    lines: list[str] = []
-    if path.suffix == ".py":
-        with path.open("r", encoding="utf-8") as f:
-            try:
-                module = ast.parse(f.read())
-                doc = ast.get_docstring(module)
-                if doc:
-                    lines = [l.strip() for l in doc.strip().splitlines() if l.strip()]
-            except SyntaxError:
-                pass
-    if not lines:
-        with path.open("r", encoding="utf-8") as f:
-            for line in f:
-                s = line.strip()
-                if s.startswith("#!"):
-                    continue
-                if s.startswith("#"):
-                    lines.append(s.lstrip("# "))
-                elif lines and s == "":
-                    break
-                elif lines:
-                    break
-    fields = []
-    for key in ("Description:", "Functioning:", "How to use:"):
-        for l in lines:
-            if l.startswith(key):
-                fields.append(l)
-                break
-    if fields:
-        return "\n".join(fields)
-    if lines:
-        return " ".join(lines)
-    return "No description available"
+  """Return the standardized description block for the script."""
+  lines: list[str] = []
+  if path.suffix == ".py":
+    with path.open("r", encoding="utf-8") as f:
+      try:
+        module = ast.parse(f.read())
+        doc = ast.get_docstring(module)
+        if doc:
+          lines = [l.strip() for l in doc.strip().splitlines() if l.strip()]
+      except SyntaxError:
+        pass
+  if not lines:
+    with path.open("r", encoding="utf-8") as f:
+      for line in f:
+        s = line.strip()
+        if s.startswith("#!"):
+          continue
+        if s.startswith("#"):
+          lines.append(s.lstrip("# "))
+        elif lines and s == "":
+          break
+        elif lines:
+          break
+  fields = []
+  for key in ("Description:", "Functioning:", "How to use:"):
+    for l in lines:
+      if l.startswith(key):
+        fields.append(l)
+        break
+  if fields:
+    return "\n".join(fields)
+  if lines:
+    return " ".join(lines)
+  return "No description available"
 
 
 def generate_readme_content() -> str:
-    scripts = sorted(Path(REPO_ROOT).glob("*.sh")) + sorted(Path(REPO_ROOT).glob("*.py"))
-    sections = []
-    for script in scripts:
-        desc = extract_description(script)
-        sections.append(f"## {script.name}\n{desc}\n")
-    return README_HEADER + "\n" + "\n".join(sections) + "\n"
+  scripts = sorted(Path(REPO_ROOT).glob("*.sh")) + sorted(
+      Path(REPO_ROOT).glob("*.py"))
+  sections = []
+  for script in scripts:
+    desc = extract_description(script)
+    sections.append(f"## {script.name}\n{desc}\n")
+  return README_HEADER + "\n" + "\n".join(sections) + "\n"
 
 
 def main() -> None:
-    content = generate_readme_content()
-    README_PATH.write_text(content, encoding="utf-8")
+  content = generate_readme_content()
+  README_PATH.write_text(content, encoding="utf-8")
 
 
 if __name__ == "__main__":
-    main()
+  main()


### PR DESCRIPTION
## Summary
- Reformat shell scripts with `shfmt` for two-space indentation
- Reindent Python utilities with `yapf` using two-space style

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `shellcheck *.sh` *(warnings: SC2046, SC2164, SC2086 in update-sops.sh)*

------
https://chatgpt.com/codex/tasks/task_b_68acbad656c0832bb3db48e70aa94386